### PR TITLE
ADX-979 Create IUploader stub for blob-storage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 2.7, 3.9 ]
+        python-version: [ 3.9 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -28,10 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ckan-container-version: "2.9-py2"
-            ckan-postgres-version: "2.9"
-            ckan-solr-version: "2.9-solr8"
-            ckan-requirements: "requirements.py2.txt"
           - ckan-container-version: "2.9"
             ckan-postgres-version: "2.9"
             ckan-solr-version: "2.9-solr8"

--- a/ckanext/blob_storage/plugin.py
+++ b/ckanext/blob_storage/plugin.py
@@ -8,7 +8,7 @@ from . import actions, authz, helpers, validators
 from .blueprints import blueprint
 from .download_handler import download_handler
 from .interfaces import IResourceDownloadHandler
-from .storage import ResourceBlobStorage
+from .storage import DummyUploader
 
 
 class BlobStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
@@ -22,9 +22,9 @@ class BlobStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     plugins.implements(plugins.IValidators)
     plugins.implements(plugins.IDatasetForm)
 
-    # IUploader
+    # dummy implementation of IUploader
     def get_resource_uploader(self, data_dict):
-        return ResourceBlobStorage(data_dict)
+        return DummyUploader(data_dict)
 
     def get_uploader(self, upload_to, old_filename=None):
         return None

--- a/ckanext/blob_storage/plugin.py
+++ b/ckanext/blob_storage/plugin.py
@@ -8,9 +8,11 @@ from . import actions, authz, helpers, validators
 from .blueprints import blueprint
 from .download_handler import download_handler
 from .interfaces import IResourceDownloadHandler
+from .storage import ResourceBlobStorage
 
 
 class BlobStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
+    plugins.implements(plugins.IUploader)
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IBlueprint)
@@ -19,6 +21,13 @@ class BlobStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     plugins.implements(IResourceDownloadHandler, inherit=True)
     plugins.implements(plugins.IValidators)
     plugins.implements(plugins.IDatasetForm)
+
+    # IUploader
+    def get_resource_uploader(self, data_dict):
+        return ResourceBlobStorage(data_dict)
+
+    def get_uploader(self, upload_to, old_filename=None):
+        return None
 
     # IDatasetForm
     def create_package_schema(self):
@@ -31,7 +40,7 @@ class BlobStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
                 toolkit.get_validator('upload_has_sha256'),
                 toolkit.get_validator('upload_has_size'),
                 toolkit.get_validator('upload_has_lfs_prefix')
-                ],
+            ],
             'sha256': [
                 toolkit.get_validator('ignore_missing'),
                 toolkit.get_validator('valid_sha256')
@@ -57,7 +66,7 @@ class BlobStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
                 toolkit.get_validator('upload_has_sha256'),
                 toolkit.get_validator('upload_has_size'),
                 toolkit.get_validator('upload_has_lfs_prefix')
-                ],
+            ],
             'sha256': [
                 toolkit.get_validator('ignore_missing'),
                 toolkit.get_validator('valid_sha256')
@@ -109,7 +118,7 @@ class BlobStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'blob_storage_server_url': helpers.server_url,
             'blob_storage_storage_namespace': helpers.storage_namespace,
             'ckan_29_or_higher': plugins.toolkit.check_ckan_version(min_version='2.9.0')
-          }
+        }
 
     # IBlueprint
 

--- a/ckanext/blob_storage/plugin.py
+++ b/ckanext/blob_storage/plugin.py
@@ -22,7 +22,7 @@ class BlobStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     plugins.implements(plugins.IValidators)
     plugins.implements(plugins.IDatasetForm)
 
-    # dummy implementation of IUploader
+    # IUploader
     def get_resource_uploader(self, data_dict):
         return DummyUploader(data_dict)
 

--- a/ckanext/blob_storage/plugin.py
+++ b/ckanext/blob_storage/plugin.py
@@ -8,7 +8,7 @@ from . import actions, authz, helpers, validators
 from .blueprints import blueprint
 from .download_handler import download_handler
 from .interfaces import IResourceDownloadHandler
-from .storage import DummyUploader
+from .uploader import DummyUploader
 
 
 class BlobStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):

--- a/ckanext/blob_storage/storage.py
+++ b/ckanext/blob_storage/storage.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import cgi
+from datetime import datetime
+
+from ckan import model
+from ckan.lib import munge
+from .download_handler import download_handler
+
+
+class ResourceBlobStorage(object):
+    def __init__(self, resource):
+        super(ResourceBlobStorage, self).__init__()
+
+    def get_path(self, id):
+        return download_handler(id)
+
+    def upload(self, id, max_size):
+        return None

--- a/ckanext/blob_storage/storage.py
+++ b/ckanext/blob_storage/storage.py
@@ -1,9 +1,0 @@
-class ResourceBlobStorage(object):
-    def __init__(self, resource):
-        return None
-
-    def get_path(self, id):
-        return None
-
-    def upload(self, id, max_size):
-        return None

--- a/ckanext/blob_storage/storage.py
+++ b/ckanext/blob_storage/storage.py
@@ -1,19 +1,9 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-import cgi
-from datetime import datetime
-
-from ckan import model
-from ckan.lib import munge
-from .download_handler import download_handler
-
-
 class ResourceBlobStorage(object):
     def __init__(self, resource):
-        super(ResourceBlobStorage, self).__init__()
+        return None
 
     def get_path(self, id):
-        return download_handler(id)
+        return None
 
     def upload(self, id, max_size):
         return None

--- a/ckanext/blob_storage/uploader.py
+++ b/ckanext/blob_storage/uploader.py
@@ -1,0 +1,12 @@
+class DummyUploader(object):
+    # this class implements a dummy IUploader interface which allows extensions like
+    # ckanext-validation to detect that there's a non-standard storage plugin used
+    # in CKAN
+    def __init__(self, resource):
+        return None
+
+    def get_path(self, id):
+        return None
+
+    def upload(self, id, max_size):
+        return None


### PR DESCRIPTION
## Description

Blob-storage doesn't implement IUploader plugin interface, hence ckanext-validation doesn't detect blob-storage as "cloud" storage plugin. This implementation just registers ckanext-blob_storage as an extension with custom uploader implementation. 


## Checklist


- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
